### PR TITLE
ヴァリデーションの実装

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,0 +1,7 @@
+class Message < ApplicationRecord
+  belongs_to :group
+  belongs_to :user
+
+  validates :content, presence: true, unless: :image?
+  mount_uploader :image, ImageUploader
+end


### PR DESCRIPTION
# what
messsage投稿時にvalidationを設定する。

# why
message本文とimageのどちらも未入力の際は、投稿できないようにするため。
どちらかのみの投稿は可とする。